### PR TITLE
Add webhook trigger for pushes to the main branch

### DIFF
--- a/.github/workflows/webhook-trigger.yaml
+++ b/.github/workflows/webhook-trigger.yaml
@@ -1,0 +1,19 @@
+name: Webhook on Main Push
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    trigger-webhook:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Send Payload to Webhook
+              env:
+                  TARGET_URL: ${{ secrets.WEBHOOK_URL }}
+              run: |
+                  curl -X POST \
+                    -H "Content-Type: application/json" \
+                    -d '${{ toJson(github.event) }}' \
+                    "$TARGET_URL"


### PR DESCRIPTION
## Description

This PR creates a workflow that gets triggered whenever there's a push to `main`. It sends a payload containing the push event details to a webhook i.e. Discord.

Closes https://github.com/yenaing-oo/cinemate/issues/38
