### PR TITLE
Fix build failing in CI due to missing environment variables

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,6 @@ import Image from "next/image";
 import Link from "next/link";
 import { Card, CardContent } from "~/components/ui/card";
 import { auth } from "~/server/auth";
-import { db } from "~/server/db";
 import { api, HydrateClient } from "~/trpc/server";
 
 const todayShowtimes = [
@@ -50,11 +49,6 @@ const nowPlaying = [
         poster: "/posters/passengers.jpg",
     },
 ];
-
-// Test statements to verify build does not fail due to missing env vars in CI
-const movies = db.movie.findMany();
-console.log("Movies from DB:", movies);
-console.log(process.env.DATABASE_URL);
 
 export default async function Home() {
     return (


### PR DESCRIPTION
## Description

Moved dummy values for Prisma environment variables `DATABASE_URL` and `DIRECT_URL` to the global scope in the PR-check Github Action. This made those dummy values available to all jobs instead of just the Prisma schema validation job.

Closes #67

### Steps to Verify
- See the test statements I added which made use of the database in https://github.com/yenaing-oo/cinemate/pull/68/commits/8c65f8bba648818274d8754920d561c239d3f920
- The build succeeded in CI
