### PR TITLE
 Redirect to Booking History Page After Payment

### DIFF
--- a/src/app/ticketing/childRoutes/checkout/checkoutReviewPage.tsx
+++ b/src/app/ticketing/childRoutes/checkout/checkoutReviewPage.tsx
@@ -142,8 +142,6 @@ export default function CheckoutReviewPage({
                         bookingSession.id,
                         $Enums.BookingStep.COMPLETED
                     );
-                    await processConfirmationEmail();
-                    router.push("/bookings");
                 } catch (error) {
                     const message =
                         error instanceof Error
@@ -155,6 +153,19 @@ export default function CheckoutReviewPage({
                     });
                     router.replace("/ticketing");
                     router.refresh();
+                    return;
+                }
+
+                try {
+                    await processConfirmationEmail();
+                } catch {
+                    toast.error(
+                        "Your reservation was confirmed, but the confirmation email could not be sent.",
+                        {
+                            description:
+                                "You can still find your latest booking on the bookings page.",
+                        }
+                    );
                 }
             }}
         />

--- a/src/app/ticketing/page.tsx
+++ b/src/app/ticketing/page.tsx
@@ -13,6 +13,8 @@ import CheckoutReviewPage from "./childRoutes/checkout/checkoutReviewPage";
 export default function TicketingPage() {
     const router = useRouter();
     const utils = api.useUtils();
+    const [shouldRedirectToBookings, setShouldRedirectToBookings] =
+        useState(false);
     const { data: session, isLoading } = api.bookingSession.get.useQuery(
         undefined,
         {
@@ -30,9 +32,9 @@ export default function TicketingPage() {
 
     useEffect(() => {
         if (!isLoading && !session) {
-            router.replace("/");
+            router.replace(shouldRedirectToBookings ? "/bookings" : "/");
         }
-    }, [isLoading, session, router]);
+    }, [isLoading, router, session, shouldRedirectToBookings]);
 
     useEffect(() => {
         if (!session?.expiresAt) return;
@@ -51,12 +53,26 @@ export default function TicketingPage() {
         ticketCount?: number,
         selectedShowtimeSeatIds?: string[]
     ) => {
-        await updateBookingSession.mutateAsync({
-            sessionId,
-            goToStep,
-            ticketCount,
-            selectedSeatIds: selectedShowtimeSeatIds,
-        });
+        const isCompletingBooking = goToStep === $Enums.BookingStep.COMPLETED;
+
+        if (isCompletingBooking) {
+            setShouldRedirectToBookings(true);
+        }
+
+        try {
+            await updateBookingSession.mutateAsync({
+                sessionId,
+                goToStep,
+                ticketCount,
+                selectedSeatIds: selectedShowtimeSeatIds,
+            });
+        } catch (error) {
+            if (isCompletingBooking) {
+                setShouldRedirectToBookings(false);
+            }
+
+            throw error;
+        }
     };
 
     return (


### PR DESCRIPTION
  ## Description

 This PR updates the booking confirmation flow so that after a user confirms a reservation, they are redirected to the existing bookings page.

  ## Changes

  - Updated the post-confirmation redirect to send users to `/bookings`

  ## How to Test

  Steps to verify this PR works as expected:

  1. Log in and start a ticket booking flow
  2. Complete the booking and click `Confirm reservation`
  3. Verify that you are redirected to the bookings page and can see the newly created booking