### PR TITLE
Add missing Docker Buildx setup step in workflow

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -58,6 +58,9 @@ jobs:
             - name: Check out the repo
               uses: actions/checkout@v5
 
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
+
             - name: Log in to Docker Hub
               uses: docker/login-action@v3.6.0
               with:


### PR DESCRIPTION
Follow-up fix for https://github.com/yenaing-oo/cinemate/pull/131